### PR TITLE
Update 2-insertTratamientosTodoCode.sql

### DIFF
--- a/2-insertTratamientosTodoCode.sql
+++ b/2-insertTratamientosTodoCode.sql
@@ -3,7 +3,7 @@ VALUES
   
   (1, 2, 'Vacunación', '2022-03-01'),
   (2, 2, 'Desparasitación', '2022-03-15'),
-  (3, 2, 'Chequeo general', '2022-04-02');
+  (3, 2, 'Chequeo general', '2022-04-02'),
   (4, 1, 'Vacunación', '2022-03-01'),
   (5, 1, 'Desparasitación', '2022-03-15'),
   (6, 1, 'Chequeo general', '2022-04-02'),


### PR DESCRIPTION
Se corrige script SQL de inserción de tratamientos, dado que antes de insertar el registro 4 tenía un caracter ";" por lo cual generaba un error al intentar ejecutar el script